### PR TITLE
Restore sizes metadata

### DIFF
--- a/bu-media-s3.php
+++ b/bu-media-s3.php
@@ -15,6 +15,7 @@ require_once dirname( __FILE__ ) . '/src/dynamodb-crop.php';
 require_once dirname( __FILE__ ) . '/src/s3-assets.php';
 require_once dirname( __FILE__ ) . '/src/filters.php';
 
+// Load the WP-CLI commands if we're running in a CLI environment.
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once dirname( __FILE__ ) . '/src/wp-cli-commands.php';
 }

--- a/bu-media-s3.php
+++ b/bu-media-s3.php
@@ -3,7 +3,7 @@
  * Plugin Name: bu-media-s3
  * Plugin URI: https://github.com/bu-ist/bu-media-s3
  * Description: A plugin for integrating S3 with WordPress
- * Version: 0.1
+ * Version: 1.0.0
  * Author: Boston University
  * Author URI: https://developer.bu.edu/
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bu-media-s3",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bu-media-s3",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Integrations between WordPress and AWS S3",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ BU Media S3 is a WordPress plugin designed to work with the [Human Made S3 Uploa
 
 - **S3 Upload Directory**: The plugin filters the `upload_dir` hook and rewrites the values in a way that is compatible with the S3 Uploads plugin and the BU Protected S3 Object Lambda stack, redirecting all media uploads to the S3 bucket. It also changes the default upload location from `wp-content/uploads` to `files`, which is the convention for BU WordPress sites.
 
-- **Prevent Image Scaling**: By default, WordPress generates a scaled derivative for every image size that is defined for the current site. Because the BU Protected S3 Object Lambda stack handles image resizing automatically, the WordPress media library only needs to handle the full sized original upload. This plugin tells WordPress not to generate any derivative sizes on upload.
+- **Prevent Image Scaling**: By default, WordPress generates a scaled derivative for every image size that is defined for the current site. Because the BU Protected S3 Object Lambda stack handles image resizing automatically, the WordPress media library only needs to handle the full sized original upload. This plugin tells WordPress not to generate any derivative sizes on upload. It preserves the attachment metadata for all of the defined sizes by generating it directly during the upload process.
 
 - **Suppress Big Image Threshold Resizing**: WordPress 5.3 introduced a new feature that automatically resizes images for "web-ready" dimensions. This plugin suppresses this feature, allowing you to upload images at their full size.
 

--- a/src/filters.php
+++ b/src/filters.php
@@ -1,6 +1,16 @@
 <?php
 /**
- * Adds filters to prevent WordPress from generating image sizes during the upload process.
+ * Media handling for S3 storage and multisite installations.
+ *
+ * This file contains functions to modify WordPress's default media handling behavior for multisite installations.
+ * It changes the upload directory paths to use Amazon S3 instead of the local filesystem, and suppresses the generation
+ * of additional image sizes during the upload process. Instead, it pre-generates metadata for these sizes without
+ * creating the actual resized images. It also disables the big image size threshold to prevent WordPress from doing any resizing
+ * on original media. When a site is deleted, it hooks into the 'wp_delete_site' action to delete the corresponding
+ * media library originals and custom crop factors from AWS resources.
+ *
+ * @link https://developer.wordpress.org/reference/hooks/upload_dir/
+ * @link https://developer.wordpress.org/reference/hooks/wp_handle_upload_prefilter/
  *
  * @package BU MediaS3
  */
@@ -43,6 +53,7 @@ function s3_multisite_upload_dir( $upload ) {
 add_filter( 'upload_dir', __NAMESPACE__ . '\s3_multisite_upload_dir' );
 
 // Conditionally adds a filter only during the upload process, this filter adds a second filter that removes all the image sizes.
+// It also adds a filter to preemptively add the sizes to the attachment metadata, otherwise the first filter would prevent the sizes from being added.
 add_filter(
 	'wp_handle_upload_prefilter',
 	function( $file ) {
@@ -59,31 +70,7 @@ add_filter(
 		// Preemptively add the sizes to the attachment metadata.
 		add_filter(
 			'wp_generate_attachment_metadata',
-			function( $metadata, $attachment_id ) {
-				// Get the registered image sizes.
-				$sizes = wp_get_registered_image_subsizes();
-
-				// Get the pathinfo for the original file.
-				$pathinfo = pathinfo( $metadata['file'] );
-
-				// Get the mime type for the original file.
-				$mime_type = get_post_mime_type( $attachment_id );
-
-				// Recalculate the sizes that would have been generated and add them to the metadata.
-				foreach ( $sizes as $size => $size_data ) {
-					// Calcualte the new filename by adding the size to the original filename using the WordPress convention.
-					$new_filename = $pathinfo['filename'] . '-' . $size_data['width'] . 'x' . $size_data['height'] . '.' . $pathinfo['extension'];
-
-					// Add the new size to the metadata.
-					$metadata['sizes'][ $size ] = array(
-						'file'      => $new_filename,
-						'width'     => $size_data['width'],
-						'height'    => $size_data['height'],
-						'mime-type' => $mime_type,
-					);
-				}
-				return $metadata;
-			},
+			__NAMESPACE__ . '\generate_metadata_sizes',
 			10,
 			2
 		);
@@ -92,6 +79,48 @@ add_filter(
 		return $file;
 	}
 );
+
+/**
+ * Generate metadata for image sizes without creating the actual resized images.
+ *
+ * This function gets the registered image sizes and calculates the filename for each size
+ * using the WordPress convention for size annotation. It then adds this information to the attachment metadata.
+ *
+ * This function is designed to be added to the wp_handle_upload_prefilter in order to restore the metadata that
+ * would have been generated. Becuase the sizes are being suppressed on upload, the actual resized images
+ * are not being created, but we still need to add the metadata for the sizes to the attachment. This function
+ * should have the effect of pre-generating the metadata for the sizes that would have been created.
+ *
+ * @param array $metadata      The attachment metadata.
+ * @param int   $attachment_id The ID of the attachment.
+ *
+ * @return array The modified attachment metadata, with added sizes.
+ */
+function generate_metadata_sizes( $metadata, $attachment_id ) {
+	// Get the registered image sizes.
+	$sizes = wp_get_registered_image_subsizes();
+
+	// Get the pathinfo for the original file.
+	$pathinfo = pathinfo( $metadata['file'] );
+
+	// Get the mime type for the original file.
+	$mime_type = get_post_mime_type( $attachment_id );
+
+	// Recalculate the sizes that would have been generated and add them to the metadata.
+	foreach ( $sizes as $size => $size_data ) {
+		// Calcualte the new filename by adding the size to the original filename using the WordPress convention.
+		$new_filename = $pathinfo['filename'] . '-' . $size_data['width'] . 'x' . $size_data['height'] . '.' . $pathinfo['extension'];
+
+		// Add the new size to the metadata.
+		$metadata['sizes'][ $size ] = array(
+			'file'      => $new_filename,
+			'width'     => $size_data['width'],
+			'height'    => $size_data['height'],
+			'mime-type' => $mime_type,
+		);
+	}
+	return $metadata;
+}
 
 // Disable the big image threshold, we don't want WordPress to do any resizing at all.
 add_filter( 'big_image_size_threshold', '__return_false' );


### PR DESCRIPTION
We want to suppress the creation of scaled versions of media when they are uploaded, and in order to do so we remove all of the defined image sizes during the upload event. This an effective way stop WordPress from doing its own image scaling (the Object Lambda will handle them separately).

This has the side effect however of preventing the size data from being written to the attachment metadata. This interferes with various expectations of core WordPress and plugins like BU Banner. 

This change addresses the problem by restoring the attachment metadata that _would_ have been created, if the sizes hadn't been suppressed at upload. It does this by adding a custom function `generate_metadata_sizes()` as a filter to the `wp_generate_attachment_metadata` event (but only during file upload).

The `generate_metadata_sizes()` function uses `wp_get_registered_image_subsizes()` to read all of the currently defined sizes and format them as the attachment metadata sizes array that would have been created. It then adds this `sizes` array back to the attachment metadata and returns it back to the filter.

This should have the effect of adding back the sizes to the database record, while continuing to prevent the actual creation of scaled image files during the upload process.