### PR TITLE
Prevents accidental S3 deletion on site delete

### DIFF
--- a/bu-media-s3.php
+++ b/bu-media-s3.php
@@ -3,7 +3,7 @@
  * Plugin Name: bu-media-s3
  * Plugin URI: https://github.com/bu-ist/bu-media-s3
  * Description: A plugin for integrating S3 with WordPress
- * Version: 1.0.0
+ * Version: 1.2.0
  * Author: Boston University
  * Author URI: https://developer.bu.edu/
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bu-media-s3",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bu-media-s3",
-      "version": "0.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@wordpress/env": "^5.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bu-media-s3",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Integrations between WordPress and AWS S3",
   "main": "index.js",
   "scripts": {

--- a/src/filters.php
+++ b/src/filters.php
@@ -122,6 +122,10 @@ add_action(
  * In a multi-network installation, this checks if the site's domain matches
  * any network domain in the current installation's wp_site table.
  *
+ * This check is only performed right now on site deletion, which is an infrequent action
+ * that requires a high level of access. So we are not using caching or a lot of validation
+ * in order to keep the code simple and reliable.
+ *
  * @param WP_Site $old_site The site object being deleted.
  * @return bool True if the site belongs to the current installation, false otherwise.
  */

--- a/src/filters.php
+++ b/src/filters.php
@@ -115,9 +115,9 @@ add_action(
  *
  * Protects against accidental deletion of content from mismatched sites
  * when a site has been incorrectly copied between environments. For example,
- * if a failed site content copy from www.bu.edu to www-test.bu.edu leaves
- * behind references to www.bu.edu in the staging environment, this function
- * ensures we don't accidentally delete the www.bu.edu media library from S3.
+ * if a failed site content copy from www.example.edu to www-test.example.edu leaves
+ * behind references to www.example.edu in the staging environment, this function
+ * ensures we don't accidentally delete the www.example.edu media library from S3.
  *
  * In a multi-network installation, this checks if the site's domain matches
  * any network domain in the current installation's wp_site table.

--- a/src/filters.php
+++ b/src/filters.php
@@ -89,6 +89,10 @@ add_filter( 'big_image_size_threshold', '__return_false' );
 add_action(
 	'wp_delete_site',
 	function ( $old_site ) {
+		// Add logging for site deletion actions to help with debugging and auditing.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( sprintf( 'wp_delete_site: initial hook, deleting S3 files and DynamoDB entries for site %s (ID: %d)', $old_site->siteurl, $old_site->id ) );
+
 		// Verify that this site belongs to the current network.
 		if ( ! site_belongs_to_current_network( $old_site ) ) {
 			// Log the attempted deletion of a site that doesn't belong to the current network.
@@ -105,6 +109,10 @@ add_action(
 
 		// Delete the custom crop factors from DynamoDB.
 		delete_dynamodb_sizes( $old_site->siteurl );
+
+		// Log completion of site deletion actions.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( sprintf( 'wp_delete_site: completed deletion of S3 files and DynamoDB entries for site %s (ID: %d)', $old_site->siteurl, $old_site->id ) );
 	},
 	10,
 	2

--- a/src/filters.php
+++ b/src/filters.php
@@ -143,7 +143,7 @@ function site_belongs_to_current_network( $old_site ) {
 	if ( ! is_multisite() ) {
 		// In non-multisite, compare the domain with current site domain.
 		$current_domain = wp_parse_url( get_option( 'siteurl' ), PHP_URL_HOST );
-		return $old_site->domain === $current_domain;
+		return wp_parse_url( $old_site->siteurl, PHP_URL_HOST ) === $current_domain;
 	}
 
 	// For multisite/multi-network, check if the domain exists in any network in this installation.
@@ -158,11 +158,15 @@ function site_belongs_to_current_network( $old_site ) {
 		return false;
 	}
 
+	// Extract domain from siteurl (which might be malformed, this is what we want to verify).
+	// The siturl is what is used to delete S3 files, so we want to verify it here.
+	$site_domain_from_siteurl = wp_parse_url( $old_site->siteurl, PHP_URL_HOST );
+
 	// Check if the site's domain matches any network domain in this installation.
 	foreach ( $network_domains as $network_domain ) {
 		// Require exact domain match to prevent cross-environment deletion.
 		// For example, this prevents sandbox.cms-devl.bu.edu from deleting www.bu.edu content.
-		if ( $old_site->domain === $network_domain ) {
+		if ( $site_domain_from_siteurl === $network_domain ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
This PR adds a safety mechanism to prevent accidental deletion of S3 assets when a site is deleted in WordPress multisite environments. The primary change is the introduction of a validation check that ensures the site being deleted actually belongs to the current WordPress installation before proceeding with S3 file deletion.

Key changes:
- Added validation logic to verify site ownership before deleting S3 assets
- Implemented logging for blocked deletion attempts to aid in auditing and debugging
- Created a new helper function to check if a site belongs to the current network by comparing domains
