### PR TITLE
Fix: Enforce `/files/` Path Constraint in S3 Deletions

### DIFF
--- a/bu-media-s3.php
+++ b/bu-media-s3.php
@@ -3,7 +3,7 @@
  * Plugin Name: bu-media-s3
  * Plugin URI: https://github.com/bu-ist/bu-media-s3
  * Description: A plugin for integrating S3 with WordPress
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: Boston University
  * Author URI: https://developer.bu.edu/
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bu-media-s3",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bu-media-s3",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@wordpress/env": "^5.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bu-media-s3",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Integrations between WordPress and AWS S3",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ BU Media S3 is a WordPress plugin designed to work with the [Human Made S3 Uploa
 
 ## Features
 
-- **S3 Upload Directory**: The plugin filters the `upload_dir` hook and rewrites the values in a way that is compatible with the S3 Uploads plugin and the BU Protected S3 Object Lambda stack, redirecting all media uploads to the S3 bucket. It also changes the default upload location from `wp-content/uploads` to `files`, which is the convention for BU WordPress sites.
+- **S3 Upload Directory**: The plugin filters the `upload_dir` hook and rewrites the values in a way that is compatible with the S3 Uploads plugin and the BU Protected S3 Object Lambda stack, redirecting all media uploads to the S3 bucket. It also changes the default upload location from `wp-content/uploads` to `files`, which is the convention for BU WordPress sites. This `/files/` path constraint is enforced on writes by this plugin and on reads by the Apache s3proxy Location regex, ensuring consistent media scoping across the system.
 
 - **Prevent Image Scaling**: By default, WordPress generates scaled derivatives for every image size defined for the current site. This plugin sets a custom filter flag during the upload process and uses it to interpose a custom Image Editor object. This approach leverages the technique used by the S3 Uploads plugin, ensuring that the core WordPress image size metadata generation remains intact while skipping the actual resizing. This allows the BU Protected S3 Object Lambda stack to handle image resizing automatically, and preserves the attachment metadata for all defined sizes.
 

--- a/src/filters.php
+++ b/src/filters.php
@@ -102,6 +102,18 @@ add_action(
 			return;
 		}
 
+		// Defense in depth: refuse main-site deletion without explicit override.
+		// WordPress core already prevents main site deletion from wp-admin, but this provides
+		// an additional safety check at the authorization boundary where we have the site object.
+		$main_site_id = get_main_site_id( $old_site->network_id );
+		if ( (int) $old_site->blog_id === (int) $main_site_id ) {
+			if ( ! apply_filters( 'bu_media_s3_allow_main_site_deletion', false ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( sprintf( 'Refused to delete main-site media for %s (ID: %d) without explicit override.', $old_site->siteurl, $old_site->blog_id ) );
+				return;
+			}
+		}
+
 		// Delete the media library originals.
 		// This may need to be wrapped in a queued job, because we can't necessarily
 		// predict how long it takes to delete the files.

--- a/src/filters.php
+++ b/src/filters.php
@@ -105,7 +105,7 @@ add_action(
 		// Delete the media library originals.
 		// This may need to be wrapped in a queued job, because we can't necessarily
 		// predict how long it takes to delete the files.
-		delete_full_media_library( $old_site->siteurl );
+		delete_full_media_library( $old_site );
 
 		// Delete the custom crop factors from DynamoDB.
 		delete_dynamodb_sizes( $old_site->siteurl );

--- a/src/s3-assets.php
+++ b/src/s3-assets.php
@@ -37,19 +37,19 @@ function new_s3_client() {
 /**
  * Delete the entire media library from S3.
  *
- * Deletes all of the original and rendered media library files from S3 for a given site url.
+ * Deletes all of the original and rendered media library files from S3 for a given site.
  *
  * @since 0.0.1
  *
- * @param string $siteurl The siteurl as reported by get_blog_details().
+ * @param WP_Site $site The site object for the site whose media should be deleted.
  *
  * @return bool True if successful, false if not.
  */
-function delete_full_media_library( $siteurl ) {
+function delete_full_media_library( $site ) {
 	// Create the S3 client, and get the bucket name and site key.
 	$s3_client = new_s3_client();
 	$bucket    = str_replace( '/original_media', '', S3_UPLOADS_BUCKET );
-	$site_key  = str_replace( array( 'http://', 'https://' ), '', $siteurl );
+	$site_key  = str_replace( array( 'http://', 'https://' ), '', $site->siteurl );
 	$site_key  = rtrim( $site_key, '/' );
 
 	// Defense in depth: refuse main-site deletion without explicit override.

--- a/src/s3-assets.php
+++ b/src/s3-assets.php
@@ -52,6 +52,32 @@ function delete_full_media_library( $siteurl ) {
 	$site_key  = str_replace( array( 'http://', 'https://' ), '', $siteurl );
 	$site_key  = rtrim( $site_key, '/' );
 
+	// Defense in depth: refuse main-site deletion without explicit override.
+	// WordPress core already prevents main site deletion from wp-admin, but this provides
+	// an additional safety check following the pattern of site_belongs_to_current_network().
+	if ( is_multisite() ) {
+		$url_parts = wp_parse_url( 'http://' . $site_key ); // Re-add protocol for parsing.
+		$domain    = $url_parts['host'];
+		$path      = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
+		$site      = get_site_by_path( $domain, $path );
+
+		// Fail closed: if we can't resolve the site, refuse deletion as a safety measure.
+		if ( ! $site ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( sprintf( 'Cannot resolve siteurl %s to a known site. Blocking deletion as a safety measure.', $siteurl ) );
+			return false;
+		}
+
+		// Check if this is the main site and block deletion unless explicitly overridden.
+		if ( is_main_site( $site->blog_id ) ) {
+			if ( ! apply_filters( 'bu_media_s3_allow_main_site_deletion', false ) ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( sprintf( 'Refused to delete main-site media for %s without explicit override.', $siteurl ) );
+				return false;
+			}
+		}
+	}
+
 	// Delete the media library originals. This may need to be wrapped in a queued job,
 	// because we can't necessarily predict how long it takes to delete the files.
 	try {

--- a/src/s3-assets.php
+++ b/src/s3-assets.php
@@ -54,10 +54,12 @@ function delete_full_media_library( $siteurl ) {
 	// because we can't necessarily predict how long it takes to delete the files.
 	try {
 		// Delete all of the original media library files.
-		$s3_client->deleteMatchingObjects( $bucket, "original_media/{$site_key}" );
+		// Add trailing slash to prevent prefix matching issues (e.g., 'sourcing' matching 'sourcing2018').
+		$s3_client->deleteMatchingObjects( $bucket, "original_media/{$site_key}/" );
 
 		// Delete all of the rendered media library files.
-		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$site_key}" );
+		// Add trailing slash to prevent prefix matching issues (e.g., 'sourcing' matching 'sourcing2018').
+		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$site_key}/" );
 
 	} catch ( AwsException $e ) {
 		// Handle the exception.
@@ -92,7 +94,8 @@ function delete_rendered_files( $siteurl ) {
 	// Delete all of the rendered media library files.
 	try {
 		// Delete all of the rendered media library files.
-		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$site_key}" );
+		// Add trailing slash to prevent prefix matching issues (e.g., 'sourcing' matching 'sourcing2018').
+		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$site_key}/" );
 
 	} catch ( AwsException $e ) {
 		// Handle the exception.
@@ -173,7 +176,8 @@ function delete_scaled_for_original( $path_fragment ) {
 	// Delete all of the rendered media library files.
 	try {
 		// Delete all of the rendered media library files.
-		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$path_fragment}" );
+		// Add trailing slash to prevent prefix matching issues (e.g., 'sourcing' matching 'sourcing2018').
+		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$path_fragment}/" );
 
 	} catch ( AwsException $e ) {
 		// Handle the exception.

--- a/src/s3-assets.php
+++ b/src/s3-assets.php
@@ -68,8 +68,11 @@ function delete_full_media_library( $siteurl ) {
 			return false;
 		}
 
-		// Check if this is the main site and block deletion unless explicitly overridden.
-		if ( is_main_site( $site->blog_id ) ) {
+		// Check if this is the main site of its network and block deletion unless explicitly overridden.
+		// Use get_main_site_id() with the resolved site's network ID to correctly identify main sites
+		// in multi-network setups (is_main_site() defaults to the current network context).
+		$main_site_id = get_main_site_id( $site->network_id );
+		if ( $site->blog_id === $main_site_id ) {
 			if ( ! apply_filters( 'bu_media_s3_allow_main_site_deletion', false ) ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				error_log( sprintf( 'Refused to delete main-site media for %s without explicit override.', $siteurl ) );

--- a/src/s3-assets.php
+++ b/src/s3-assets.php
@@ -8,6 +8,7 @@
 namespace BU\Plugins\MediaS3;
 
 use Aws\S3\S3Client;
+use Aws\Exception\AwsException;
 
 /**
  * Get the S3 client.

--- a/src/s3-assets.php
+++ b/src/s3-assets.php
@@ -38,6 +38,8 @@ function new_s3_client() {
  * Delete the entire media library from S3.
  *
  * Deletes all of the original and rendered media library files from S3 for a given site.
+ * Authorization checks (network membership, main-site guards) should be performed by the caller
+ * before invoking this function. This function focuses on the deletion execution.
  *
  * @since 0.0.1
  *
@@ -51,35 +53,6 @@ function delete_full_media_library( $site ) {
 	$bucket    = str_replace( '/original_media', '', S3_UPLOADS_BUCKET );
 	$site_key  = str_replace( array( 'http://', 'https://' ), '', $site->siteurl );
 	$site_key  = rtrim( $site_key, '/' );
-
-	// Defense in depth: refuse main-site deletion without explicit override.
-	// WordPress core already prevents main site deletion from wp-admin, but this provides
-	// an additional safety check following the pattern of site_belongs_to_current_network().
-	if ( is_multisite() ) {
-		$url_parts = wp_parse_url( 'http://' . $site_key ); // Re-add protocol for parsing.
-		$domain    = $url_parts['host'];
-		$path      = isset( $url_parts['path'] ) ? $url_parts['path'] : '/';
-		$site      = get_site_by_path( $domain, $path );
-
-		// Fail closed: if we can't resolve the site, refuse deletion as a safety measure.
-		if ( ! $site ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( sprintf( 'Cannot resolve siteurl %s to a known site. Blocking deletion as a safety measure.', $siteurl ) );
-			return false;
-		}
-
-		// Check if this is the main site of its network and block deletion unless explicitly overridden.
-		// Use get_main_site_id() with the resolved site's network ID to correctly identify main sites
-		// in multi-network setups (is_main_site() defaults to the current network context).
-		$main_site_id = get_main_site_id( $site->network_id );
-		if ( $site->blog_id === $main_site_id ) {
-			if ( ! apply_filters( 'bu_media_s3_allow_main_site_deletion', false ) ) {
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-				error_log( sprintf( 'Refused to delete main-site media for %s without explicit override.', $siteurl ) );
-				return false;
-			}
-		}
-	}
 
 	// Delete the media library originals. This may need to be wrapped in a queued job,
 	// because we can't necessarily predict how long it takes to delete the files.

--- a/src/s3-assets.php
+++ b/src/s3-assets.php
@@ -175,9 +175,12 @@ function delete_scaled_for_original( $path_fragment ) {
 
 	// Delete all of the rendered media library files.
 	try {
-		// Delete all of the rendered media library files.
-		// Add trailing slash to prevent prefix matching issues (e.g., 'sourcing' matching 'sourcing2018').
-		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$path_fragment}/" );
+		// Delete scaled derivatives (e.g., 'image-300x300.jpg') for the given original.
+		// Prefix matching without trailing slash is intentional: rendered_media contains only
+		// regeneratable scaled files, so minor over-deletion (e.g., 'image' matching 'image2-300x300.jpg')
+		// is acceptable. The original is preserved, and any new request will regenerate the scaled file.
+		// This differs from original deletions where trailing slashes are critical to prevent cross-site data loss.
+		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$path_fragment}" );
 
 	} catch ( AwsException $e ) {
 		// Handle the exception.

--- a/src/s3-assets.php
+++ b/src/s3-assets.php
@@ -50,17 +50,17 @@ function delete_full_media_library( $siteurl ) {
 	$s3_client = new_s3_client();
 	$bucket    = str_replace( '/original_media', '', S3_UPLOADS_BUCKET );
 	$site_key  = str_replace( array( 'http://', 'https://' ), '', $siteurl );
+	$site_key  = rtrim( $site_key, '/' );
 
 	// Delete the media library originals. This may need to be wrapped in a queued job,
 	// because we can't necessarily predict how long it takes to delete the files.
 	try {
-		// Delete all of the original media library files.
-		// Add trailing slash to prevent prefix matching issues (e.g., 'sourcing' matching 'sourcing2018').
-		$s3_client->deleteMatchingObjects( $bucket, "original_media/{$site_key}/" );
-
-		// Delete all of the rendered media library files.
-		// Add trailing slash to prevent prefix matching issues (e.g., 'sourcing' matching 'sourcing2018').
-		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$site_key}/" );
+		// Uploads are constrained to /files/ by s3_multisite_upload_dir() (the upload_dir filter
+		// in filters.php). The Apache s3proxy Location regex ^/+([^/]+/){0,2}files/ enforces
+		// the same scope on reads. Deletion MUST match the same scope, or a root-site delete
+		// (e.g. www.bu.edu) would catch every nested subsite (e.g. www.bu.edu/admissions/files/).
+		$s3_client->deleteMatchingObjects( $bucket, "original_media/{$site_key}/files/" );
+		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$site_key}/files/" );
 
 	} catch ( AwsException $e ) {
 		// Handle the exception.
@@ -91,12 +91,14 @@ function delete_rendered_files( $siteurl ) {
 	$s3_client = new_s3_client();
 	$bucket    = str_replace( '/original_media', '', S3_UPLOADS_BUCKET );
 	$site_key  = str_replace( array( 'http://', 'https://' ), '', $siteurl );
+	$site_key  = rtrim( $site_key, '/' );
 
 	// Delete all of the rendered media library files.
 	try {
-		// Delete all of the rendered media library files.
-		// Add trailing slash to prevent prefix matching issues (e.g., 'sourcing' matching 'sourcing2018').
-		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$site_key}/" );
+		// Uploads are constrained to /files/ by s3_multisite_upload_dir(). Deletion must match
+		// the same scope to avoid root-site operations matching subsites (e.g., www.bu.edu
+		// catching www.bu.edu/admissions/files/).
+		$s3_client->deleteMatchingObjects( $bucket, "rendered_media/{$site_key}/files/" );
 
 	} catch ( AwsException $e ) {
 		// Handle the exception.


### PR DESCRIPTION
The previous version of the S3 file deletion code had two failure modes that had the same root cause. S3 prefix matching is literal string matching, so `original_media/www.bu.edu/sourcing` matches both `sourcing` and `sourcing2018`, and `original_media/www.bu.edu` matches every subsite under it. This happened in production on Feb 18, 2026: a move on `cms-attic.bu.edu/sourcing` deleted files from `cms-attic.bu.edu/sourcing2018`. The history for this is documented in Slack discussions when we discovered this on March 3. The second failure is with root sites, where deleting `www.bu.edu` as a root site would catch every subsite below it.

Both are fixed by ensuring that deletion paths now always end in `/files/`. This leverages an architectural constraint we already implement in our custom S3 WP media system.

## The `/files/` constraint

Every media key in the bucket contains `/files/` somewhere in its path:

| Bucket prefix | Site scope | Key path |
|---|---|---|
| `original_media/` | root site | `original_media/www.bu.edu/files/...` |
| `original_media/` | subsite | `original_media/www.bu.edu/admissions/files/...` |
| `rendered_media/` | root site | `rendered_media/www.bu.edu/files/...` |
| `rendered_media/` | subsite | `rendered_media/www.bu.edu/admissions/files/...` |

This is enforced at two code points already:

- **Writes:** `s3_multisite_upload_dir()` in this plugin rewrites the WordPress upload directory to `files`.
- **Reads:** The Apache s3proxy `Location` regex `^/+([^/]+/){0,2}files/` only proxies URLs that contain `/files/`.

The change in this PR leverages this pattern to make `deleteMatchingObjects` more precise, by adding`/files/` to the end of the deletion path.

With `/files/` in the path, root and subsite key spaces are protected from each other, and overlapping site names (`sourcing` vs. `sourcing2018`) no longer collide because the next path segment terminates the match.

Root site deletions will also be scoped appropriately to just the root sites `files` path.

## Changes

**`delete_full_media_library($site)`** — called from the `wp_delete_site` hook to remove a site's entire media library.

- Deletion prefixes scoped to `/files/`: `original_media/{$site_key}/files/` and `rendered_media/{$site_key}/files/`
- Signature changed from siteurl string to a `WP_Site` object. The function is now a pure deletion executor; authorization is the caller's responsibility (documented in the docblock)
- `$site_key` normalized with `rtrim` to defend against callers passing a trailing slash

**`wp_delete_site` hook handler in `filters.php`** — now the authorization layer for site-level deletion.

- Existing guard: `site_belongs_to_current_network()` (catches cross-environment deletion).
- New guard: main-site protection. If the resolved site is the main site of its network, deletion is refused unless `bu_media_s3_allow_main_site_deletion` is filtered to true. WordPress core already blocks main-site deletion from wp-admin; this is defense-in-depth at the boundary where we have the `WP_Site` object.
- Override usage for legitimate cases (e.g., decommissioning an entire network):
  ```php
  add_filter( 'bu_media_s3_allow_main_site_deletion', '__return_true' );
  ```

**`delete_rendered_files($siteurl)`** — called from `site-manager` move operations.

- Deletion prefix scoped to `/files/`: `rendered_media/{$site_key}/files/`.
- `$site_key` normalized with `rtrim`.
- No main-site guard. Rendered media is regeneratable; over-deletion is recoverable.

**`use Aws\Exception\AwsException;` added.** The file's `catch ( AwsException $e )` blocks were resolving to `BU\Plugins\MediaS3\AwsException` (which does not exist) due to the missing use statement, so they were never actually catching AWS exceptions. Side fix.

## What deliberately does not change

`delete_scaled_for_original($path_fragment)` operates at the *individual file* level — it removes scaled derivatives (`image-300x300.jpg`, `image-150x150.jpg`) of a single original. The prefix here is intentionally not slash-terminated, because adding a slash would only match files under an `image/` directory that doesn't exist and silently break derivative cleanup.

Over-deletion in this function is acceptable: `rendered_media/` is regeneratable cache, the original is preserved, and any over-matched derivative is re-created on the next request. The asymmetric risk profile between originals (irreplaceable) and derivatives (regeneratable) is what permits this looser scoping. The function's comment makes this explicit.

## Operational notes

A manual sample of `original_media/` found a small number of historical keys outside `/files/` on a disconnected attic site (likely pre-constraint uploads). These are no longer cleaned up by site deletion, but they are not reachable anyway — the read-side proxy does not proxy URLs without `/files/`. Cleanup of historical orphans, if desired, is a separate operational task.

## Background

The bug was discovered in production on Feb 18, 2026. Discussion in Slack starting March 18 initially centered on adding a trailing slash to the deletion prefix. This PR uses the full `/files/` segment instead — a more precise scope that also closes the root-vs-subsite case a trailing slash alone would not have caught.

## Testing scenarios

1. **Overlapping site names:** create sites `test` and `testing`, upload media to both, delete `test`, verify `testing` is unaffected.
2. **Root-site protection:** attempt `wp site delete <main-site>`; verify refusal is logged. With the override filter set, verify it proceeds.
3. **Subsite deletion preserves root:** delete a subsite, verify the root's media is intact.
4. **Site-manager move operations:** perform a `move-blog`, verify the source's rendered cache is cleaned without touching siblings.
5. **Derivative cleanup:** delete a media file via the media library, verify old scaled versions are removed and new ones generate on first request.